### PR TITLE
feat: create GitHub prereleases for alpha and beta publishes

### DIFF
--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -63,7 +63,26 @@ jobs:
       - name: Create snapshot prerelease version
         run: pnpm changeset version --snapshot ${{ env.CHANNEL }}
 
+      - name: Read published version
+        id: pkg
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
       - name: Publish prerelease
         run: pnpm run release:${{ env.CHANNEL }}
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create GitHub prerelease
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.pkg.outputs.version }}
+          CHANNEL: ${{ env.CHANNEL }}
+        run: |
+          NOTES="Prerelease published from branch $GITHUB_REF_NAME on channel '$CHANNEL'. Install with: npm i drizzle-cursor@$CHANNEL"
+          if gh release view "v$VERSION" >/dev/null 2>&1; then
+            gh release edit "v$VERSION" --prerelease --title "v$VERSION" --notes "$NOTES"
+          else
+            gh release create "v$VERSION" --target "$GITHUB_SHA" --prerelease --title "v$VERSION" --notes "$NOTES"
+          fi


### PR DESCRIPTION
## Summary
- extend prerelease publish workflow to also create/update GitHub prerelease entries
- use the snapshot version generated in CI as the release tag/title (`v<version>`)
- include release notes with branch name, channel, and install command

## Why
NPM prerelease tags are useful, but this makes alpha/beta drops visible in GitHub Releases as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the prerelease publication workflow to automatically capture and publish package versions, including creating GitHub releases with proper versioning tags and release notes for improved tracking of prerelease builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->