### PR TITLE
feat: start drizzle v1 beta compatibility support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,5 +24,5 @@ jobs:
       - run: pnpm add drizzle-orm@${{ matrix.drizzle-version }} -D
       - if: matrix.drizzle-version == '0.45.2'
         run: pnpm run lint
-      - run: pnpm run test
+      - run: pnpm exec vitest run
       - run: pnpm run build

--- a/README.md
+++ b/README.md
@@ -13,6 +13,16 @@ Check example at: [test/example.ts](./test/example.ts)
 npm install drizzle-cursor
 ```
 
+## Compatibility
+
+- Drizzle `0.x`: supported
+- Drizzle `1.0.0-beta.x`: supported in beta
+
+Notes:
+
+- The query-builder flow (`db.select().from(...).where(cursor.where(...)).orderBy(...cursor.orderBy)`) is the most consistently supported cross-version path today.
+- Relational query APIs changed in Drizzle v1 (`db.query`/RQB v2). If you are migrating relational queries, validate behavior in your project before production rollout.
+
 > [!NOTE]
 >
 > Check types at [`TSDocs`](https://tsdocs.dev/docs/drizzle-cursor/latest/index.html)

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "author": "Santiago Montoya <xantiagoma@gmail.com>",
   "license": "MIT",
   "peerDependencies": {
-    "drizzle-orm": ">= 0.33.0 < 1"
+    "drizzle-orm": ">= 0.33.0 < 2"
   },
   "devDependencies": {
     "@changesets/cli": "^2.27.1",


### PR DESCRIPTION
## Summary
- widen `drizzle-orm` peer dependency range to include v1 beta line
- add README compatibility notes for Drizzle 0.x and 1.0.0-beta.x
- keep CI matrix lanes for Drizzle 0.45.2 and beta, with lint restricted to 0.45.2 lane for now

## Notes
This is the initial compatibility slice so we can start publishing alpha builds and continue iterating on deeper type-level and relational-query compatibility in follow-up PRs.