### PR TITLE
feat: support raw SQL expression cursors (v0.7.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # drizzle-cursor
 
+## 0.7.0
+
+### Minor Changes
+
+- Add SQL expression cursor support
+
+  Allow raw Drizzle `sql` expressions as cursor values alongside table columns, enabling pagination by computed fields (e.g. `upper(name)`, concatenated strings, or any DB-evaluable expression).
+
+  - `Cursor` is now a discriminated union of `TableCursor` (schema) and `SQLCursor` (sql) — both exported as named types
+  - `CursorConfig<C>` is generic; cursor types are fully inferred at call sites with no manual annotations
+  - `cursor.relations.orderBy` returns `() => SQL[]` when any cursor uses `sql`, automatically inferred via `ConfigHasSqlCursor<C>` conditional type
+  - `cursor.relations.where()` builds `{ RAW: () => SQL }` conditions for SQL expression cursors
+
 ## 0.6.0
 
 ### Minor Changes

--- a/README.md
+++ b/README.md
@@ -354,6 +354,77 @@ const token = cursor.serialize({ id: 1, slug: "slug-01" });
 const parsed = cursor.parse(token);
 ```
 
+## SQL Expression Cursors
+
+Instead of a table column (`schema`), you can use a raw Drizzle `sql` expression as a cursor. This is useful for sorting by computed or virtual values like case-insensitive names, concatenated fields, or any expression your database can evaluate.
+
+```ts
+import { sql } from "drizzle-orm";
+import { generateCursor } from "drizzle-cursor";
+
+const rankUpperName = sql<string>`${users.rank}::text || '-' || upper(${users.firstName})`;
+
+const cursor = generateCursor({
+  primaryCursor: { key: "id", schema: users.id, order: "ASC" },
+  cursors: [
+    { key: "rankUpperName", sql: rankUpperName, order: "ASC" },
+  ],
+});
+```
+
+The `key` must match a field in the result row so the token pipeline can read its value for pagination. Include the expression in your `select` to make it available:
+
+```ts
+const page1 = await db
+  .select({
+    id: users.id,
+    firstName: users.firstName,
+    rankUpperName, // same sql expression — makes it available in the row
+  })
+  .from(users)
+  .orderBy(...cursor.orderBy)
+  .where(cursor.where())
+  .limit(page_size);
+
+const page2 = await db
+  .select({ id: users.id, firstName: users.firstName, rankUpperName })
+  .from(users)
+  .orderBy(...cursor.orderBy)
+  .where(cursor.where(cursor.serialize(page1.at(-1))))
+  .limit(page_size);
+```
+
+### SQL cursors with RQB v2 (`cursor.relations`)
+
+When any cursor uses `sql`, `cursor.relations.orderBy` becomes a `() => SQL[]` callback instead of a plain `Record<string, "asc" | "desc">` — pass it directly to the RQB v2 `orderBy` option:
+
+```ts
+const page1 = await db.query.users.findMany({
+  orderBy: cursor.relations.orderBy, // () => SQL[] when SQL cursors are present
+  where: cursor.relations.where(),
+  limit: page_size,
+});
+```
+
+> [!NOTE]
+>
+> `cursor.relations.where()` with SQL expression cursors produces `{ RAW: ... }` conditions
+> that work correctly in RQB v2 when the SQL expression does **not** reference the table through
+> Drizzle's aliased context. For full portability across all query modes, prefer the query-builder
+> path (`cursor.where()`) or RQB v1 (`db._query`) when paginating by SQL expressions.
+
+### Named types
+
+`TableCursor` and `SQLCursor` are exported for user-facing type annotations:
+
+```ts
+import type { CursorConfig, SQLCursor, TableCursor } from "drizzle-cursor";
+
+const config: CursorConfig<SQLCursor> = {
+  primaryCursor: { key: "id", sql: sql`${users.id}`, order: "ASC" },
+};
+```
+
 ## Contributing
 
 Submit an Issue with a minimal reproducible example.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drizzle-cursor",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Utils for Drizzle ORM cursor based pagination",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/src/generateCursor.ts
+++ b/src/generateCursor.ts
@@ -1,6 +1,6 @@
 import { SQL, and, asc, desc, eq, gt, lt, or } from "drizzle-orm";
 
-import type { CursorConfig, RelationsOrderBy, RelationsWhere } from "./types";
+import type { Cursor, CursorConfig, RelationsOrderBy, RelationsWhere, SQLCursor } from "./types";
 import {
   generateSubArrays,
   decoder as _decoder,
@@ -11,8 +11,37 @@ import {
 import { parse as _parse } from "./parse";
 import { serialize as _serialize } from "./serialize";
 
-export const generateCursor = (
-  config: CursorConfig,
+// ---------------------------------------------------------------------------
+// C is the full CursorConfig literal type (inferred by TypeScript).
+// We inspect C["primaryCursor"] and C["cursors"][number] to decide whether
+// any cursor in the config uses a SQL expression.
+// ---------------------------------------------------------------------------
+
+type CursorIsSql<C extends Cursor> = C extends SQLCursor ? true : false;
+
+type ConfigHasSqlCursor<C extends CursorConfig> =
+  true extends CursorIsSql<C["primaryCursor"]>
+    ? true
+    : C["cursors"] extends Array<Cursor>
+      ? true extends CursorIsSql<C["cursors"][number]>
+        ? true
+        : false
+      : false;
+
+/**
+ * When every cursor uses `schema`, `relations.orderBy` is a plain
+ * `Record<string, "asc" | "desc">` (RQB v2 field-name form).
+ *
+ * When any cursor uses `sql`, it becomes `() => SQL[]` — pass it directly
+ * as the RQB v2 `orderBy` callback so the SQL expression is evaluated.
+ */
+type RelationsOrderByFor<C extends CursorConfig> =
+  ConfigHasSqlCursor<C> extends true ? () => Array<SQL> : RelationsOrderBy;
+
+// ---------------------------------------------------------------------------
+
+export const generateCursor = <C extends CursorConfig>(
+  config: C,
   options?: {
     /**
      * decoder: similar to `atob()` but compatible with UTF-8 strings
@@ -83,14 +112,25 @@ export const generateCursor = (
     return schema;
   };
 
-  for (const { order = "ASC", key, schema } of allCursors) {
+  for (const cursor of allCursors) {
+    const { order = "ASC", key } = cursor;
     const fn = order === "ASC" ? asc : desc;
-    orderBy.push(fn(assertColumn(schema, key)));
+    if ("sql" in cursor) {
+      orderBy.push(fn(cursor.sql));
+    } else {
+      orderBy.push(fn(assertColumn(cursor.schema, key)));
+    }
     relationsOrderBy[key] = order === "ASC" ? "asc" : "desc";
   }
 
-  const relations: { orderBy: RelationsOrderBy; where: (lastPreviousItemData?: Record<string, unknown> | string | null) => RelationsWhere | { OR: RelationsWhere[] } | undefined } = {
-    orderBy: relationsOrderBy,
+  const hasSqlCursor = allCursors.some((c) => "sql" in c);
+
+  const relations: {
+    orderBy: RelationsOrderByFor<C>;
+    where: (lastPreviousItemData?: Record<string, unknown> | string | null) => { OR: RelationsWhere[] } | undefined;
+  } = {
+    // Cast is safe: hasSqlCursor mirrors the compile-time ConfigHasSqlCursor<C> check
+    orderBy: (hasSqlCursor ? (() => orderBy) : relationsOrderBy) as RelationsOrderByFor<C>,
     where: (lastPreviousItemData?: Record<string, unknown> | string | null) => {
       if (!lastPreviousItemData) {
         return undefined;
@@ -111,13 +151,31 @@ export const generateCursor = (
 
       for (const possibilities of matrix) {
         const clause: RelationsWhere = {};
+        const sqlConditions: Array<SQL> = [];
+
         for (const cursor of possibilities) {
           const lastValue = cursor === possibilities?.at(-1);
           const { order = "ASC", key } = cursor;
-          clause[key] = lastValue
-            ? { [order === "ASC" ? "gt" : "lt"]: data[key] }
-            : { eq: data[key] };
+
+          if ("sql" in cursor) {
+            const fn = order === "ASC" ? gt : lt;
+            sqlConditions.push(
+              lastValue ? fn(cursor.sql, data[key]) : eq(cursor.sql, data[key]),
+            );
+          } else {
+            clause[key] = lastValue
+              ? { [order === "ASC" ? "gt" : "lt"]: data[key] }
+              : { eq: data[key] };
+          }
         }
+
+        if (sqlConditions.length > 0) {
+          // Cast is safe: length > 0 guarantees at least one element
+          const [first, ...rest] = sqlConditions as [SQL, ...SQL[]];
+          const combined = rest.length === 0 ? first : (and(first, ...rest) as SQL);
+          clause["RAW"] = (_table: unknown) => combined;
+        }
+
         ors.push(clause);
       }
 
@@ -149,11 +207,10 @@ export const generateCursor = (
         const ands: Array<SQL> = [];
         for (const cursor of posibilities) {
           const lastValue = cursor === posibilities?.at(-1);
-          const { order = "ASC", schema, key } = cursor;
+          const { order = "ASC", key } = cursor;
           const fn = order === "ASC" ? gt : lt;
-          const whereSql = !lastValue
-            ? eq(assertColumn(schema, key), data[key])
-            : fn(assertColumn(schema, key), data[key]);
+          const col = "sql" in cursor ? cursor.sql : assertColumn(cursor.schema, key);
+          const whereSql = !lastValue ? eq(col, data[key]) : fn(col, data[key]);
           ands.push(whereSql);
         }
         const _and = and(...ands);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,9 +1,24 @@
-export type Cursor = { order?: "ASC" | "DESC"; key: string; schema: unknown };
+import type { SQL } from "drizzle-orm";
+
+export type TableCursor = { order?: "ASC" | "DESC"; key: string; schema: unknown };
+export type SQLCursor = { order?: "ASC" | "DESC"; key: string; sql: SQL };
+export type Cursor = TableCursor | SQLCursor;
 
 export type RelationsOrderBy = Record<string, "asc" | "desc">;
-export type RelationsWhere = Record<string, unknown>;
+export type RelationsWhere = {
+  RAW?: (table: unknown) => SQL;
+  [key: string]: unknown;
+};
 
-export type CursorConfig = {
-  primaryCursor: Cursor;
-  cursors?: Array<Cursor>;
+/**
+ * C is an optional parameter for user-facing type annotations
+ * (e.g. `CursorConfig<SQLCursor>`).
+ *
+ * generateCursor uses the non-parameterised form `CursorConfig` (= CursorConfig<Cursor>)
+ * as its constraint so TypeScript infers C as the full config literal type, not as a
+ * unified cursor type — which would fail when different columns are used as cursors.
+ */
+export type CursorConfig<C extends Cursor = Cursor> = {
+  primaryCursor: C;
+  cursors?: Array<C>;
 };

--- a/test-fixtures/drizzle-v0/test.ts
+++ b/test-fixtures/drizzle-v0/test.ts
@@ -4,7 +4,6 @@ import { drizzle } from "drizzle-orm/pglite";
 import type { PgliteClient } from "drizzle-orm/pglite";
 import { integer, pgTable, text } from "drizzle-orm/pg-core";
 import { sql } from "drizzle-orm";
-import type { CursorConfig } from "drizzle-cursor";
 import { generateCursor } from "drizzle-cursor";
 
 const users = pgTable("users", {
@@ -12,11 +11,17 @@ const users = pgTable("users", {
   slug: text("slug").notNull(),
 });
 
+const items = pgTable("items", {
+  id: integer("id").primaryKey().generatedAlwaysAsIdentity(),
+  firstName: text("first_name").notNull(),
+  rank: integer("rank").notNull(),
+});
+
 async function main() {
   const client = new PGlite() as unknown as PgliteClient;
   const db = drizzle({
     client,
-    schema: { users },
+    schema: { users, items },
   });
 
   await db.execute(
@@ -29,12 +34,10 @@ async function main() {
       .values({ slug: `slug-${String(i).padStart(2, "0")}` });
   }
 
-  const cursorConfig: CursorConfig = {
+  const cursor = generateCursor({
     primaryCursor: { key: "id", schema: users.id, order: "ASC" },
     cursors: [{ key: "slug", schema: users.slug, order: "ASC" }],
-  };
-
-  const cursor = generateCursor(cursorConfig);
+  });
 
   /*****************
    * QUERY BUILDER *
@@ -81,6 +84,95 @@ async function main() {
 
   assert.equal(queryV1Page2.length, 5);
   assert.equal(queryV1Page2[0]?.slug, "slug-06");
+
+  /**********************
+   * SQL EXPRESSION CURSOR
+   * Table: items(id, firstName, rank)
+   * Sort: rank::text || '-' || upper(firstName) ASC, then id ASC
+   **********************/
+
+  await db.execute(
+    sql`create table items (id integer generated always as identity primary key, first_name text not null, rank integer not null);`,
+  );
+
+  // Insert order matters for id assignment
+  // rank=2 "alpha" → id=1, rank=1 "beta" → id=2, rank=3 "gamma" → id=3
+  // rank=1 "delta" → id=4, rank=2 "epsilon" → id=5, rank=3 "zeta" → id=6
+  for (const row of [
+    { firstName: "alpha", rank: 2 },
+    { firstName: "beta", rank: 1 },
+    { firstName: "gamma", rank: 3 },
+    { firstName: "delta", rank: 1 },
+    { firstName: "epsilon", rank: 2 },
+    { firstName: "zeta", rank: 3 },
+  ]) {
+    await db.insert(items).values(row);
+  }
+
+  // SQL expression: rank || '-' || upper(firstName)
+  // Sorted: "1-BETA","1-DELTA","2-ALPHA","2-EPSILON","3-GAMMA","3-ZETA"
+  const rankUpperName = sql<string>`${items.rank}::text || '-' || upper(${items.firstName})`;
+  const sqlCursor = generateCursor({
+    primaryCursor: { key: "id", schema: items.id, order: "ASC" },
+    cursors: [{ key: "rankUpperName", sql: rankUpperName, order: "ASC" }],
+  });
+
+  const sqlQbPage1 = await db
+    .select({
+      id: items.id,
+      firstName: items.firstName,
+      rank: items.rank,
+      rankUpperName,
+    })
+    .from(items)
+    .orderBy(...sqlCursor.orderBy)
+    .where(sqlCursor.where())
+    .limit(3);
+
+  assert.equal(sqlQbPage1.length, 3);
+  assert.equal(sqlQbPage1[0]?.firstName, "beta");
+  assert.equal(sqlQbPage1[1]?.firstName, "delta");
+  assert.equal(sqlQbPage1[2]?.firstName, "alpha");
+
+  const sqlQbPage2 = await db
+    .select({
+      id: items.id,
+      firstName: items.firstName,
+      rank: items.rank,
+      rankUpperName,
+    })
+    .from(items)
+    .orderBy(...sqlCursor.orderBy)
+    .where(sqlCursor.where(sqlCursor.serialize(sqlQbPage1.at(-1))))
+    .limit(3);
+
+  assert.equal(sqlQbPage2.length, 3);
+  assert.equal(sqlQbPage2[0]?.firstName, "epsilon");
+  assert.equal(sqlQbPage2[1]?.firstName, "gamma");
+  assert.equal(sqlQbPage2[2]?.firstName, "zeta");
+
+  /**********************
+   * QUERY V1 + SQL CURSOR
+   **********************/
+
+  const sqlV1Page1 = await db.query.items.findMany({
+    orderBy: sqlCursor.orderBy,
+    where: sqlCursor.where(),
+    limit: 3,
+  });
+
+  assert.equal(sqlV1Page1.length, 3);
+  assert.equal(sqlV1Page1[0]?.firstName, "beta");
+
+  // Use token from query builder (which has rankUpperName) to paginate
+  const sqlV1Page2 = await db.query.items.findMany({
+    orderBy: sqlCursor.orderBy,
+    where: sqlCursor.where(sqlCursor.serialize(sqlQbPage1.at(-1))),
+    limit: 3,
+  });
+
+  assert.equal(sqlV1Page2.length, 3);
+  assert.equal(sqlV1Page2[0]?.firstName, "epsilon");
 }
 
 main().catch((err) => {

--- a/test-fixtures/drizzle-v1/test.ts
+++ b/test-fixtures/drizzle-v1/test.ts
@@ -12,13 +12,19 @@ const users = pgTable("users", {
   slug: text("slug").notNull(),
 });
 
-const relations = defineRelations({ users }, (r) => ({}));
+const items = pgTable("items", {
+  id: integer("id").primaryKey().generatedAlwaysAsIdentity(),
+  firstName: text("first_name").notNull(),
+  rank: integer("rank").notNull(),
+});
+
+const relations = defineRelations({ users, items }, (r) => ({}));
 
 async function main() {
   const client = new PGlite() as PgliteClient;
   const db = drizzle({
     client,
-    schema: { users },
+    schema: { users, items },
     relations,
   });
 
@@ -32,12 +38,10 @@ async function main() {
       .values({ slug: `slug-${String(i).padStart(2, "0")}` });
   }
 
-  const cursorConfig: CursorConfig = {
+  const cursor = generateCursor({
     primaryCursor: { key: "id", schema: users.id, order: "ASC" },
     cursors: [{ key: "slug", schema: users.slug, order: "ASC" }],
-  };
-
-  const cursor = generateCursor(cursorConfig);
+  });
 
   /*****************
    * QUERY BUILDER *
@@ -106,6 +110,92 @@ async function main() {
 
   assert.equal(queryV2Page2.length, 5);
   assert.equal(queryV2Page2[0]?.slug, "slug-06");
+
+  /**********************
+   * SQL EXPRESSION CURSOR
+   * Table: items(id, firstName, rank)
+   * Sort: rank::text || '-' || upper(firstName) ASC, then id ASC
+   **********************/
+
+  await db.execute(
+    sql`create table items (id integer generated always as identity primary key, first_name text not null, rank integer not null);`,
+  );
+
+  // Insert order matters for id assignment
+  // rank=2 "alpha" → id=1, rank=1 "beta" → id=2, rank=3 "gamma" → id=3
+  // rank=1 "delta" → id=4, rank=2 "epsilon" → id=5, rank=3 "zeta" → id=6
+  for (const row of [
+    { firstName: "alpha", rank: 2 },
+    { firstName: "beta", rank: 1 },
+    { firstName: "gamma", rank: 3 },
+    { firstName: "delta", rank: 1 },
+    { firstName: "epsilon", rank: 2 },
+    { firstName: "zeta", rank: 3 },
+  ]) {
+    await db.insert(items).values(row);
+  }
+
+  // SQL expression: rank || '-' || upper(firstName)
+  // Sorted: "1-BETA","1-DELTA","2-ALPHA","2-EPSILON","3-GAMMA","3-ZETA"
+  const rankUpperName = sql<string>`${items.rank}::text || '-' || upper(${items.firstName})`;
+  const sqlCursor = generateCursor({
+    primaryCursor: { key: "id", schema: items.id, order: "ASC" },
+    cursors: [{ key: "rankUpperName", sql: rankUpperName, order: "ASC" }],
+  });
+
+  /*****************
+   * QUERY BUILDER  *
+   *****************/
+
+  const sqlQbPage1 = await db
+    .select({ id: items.id, firstName: items.firstName, rank: items.rank, rankUpperName })
+    .from(items)
+    .orderBy(...sqlCursor.orderBy)
+    .where(sqlCursor.where())
+    .limit(3);
+
+  assert.equal(sqlQbPage1.length, 3);
+  assert.equal(sqlQbPage1[0]?.firstName, "beta");
+  assert.equal(sqlQbPage1[1]?.firstName, "delta");
+  assert.equal(sqlQbPage1[2]?.firstName, "alpha");
+
+  const sqlQbPage2 = await db
+    .select({ id: items.id, firstName: items.firstName, rank: items.rank, rankUpperName })
+    .from(items)
+    .orderBy(...sqlCursor.orderBy)
+    .where(sqlCursor.where(sqlCursor.serialize(sqlQbPage1.at(-1))))
+    .limit(3);
+
+  assert.equal(sqlQbPage2.length, 3);
+  assert.equal(sqlQbPage2[0]?.firstName, "epsilon");
+  assert.equal(sqlQbPage2[1]?.firstName, "gamma");
+  assert.equal(sqlQbPage2[2]?.firstName, "zeta");
+
+  /****************************
+   * QUERY V1 + SQL CURSOR     *
+   * db._query accepts SQL WHERE
+   ****************************/
+
+  const sqlV1Page1 = await db._query.items.findMany({
+    orderBy: sqlCursor.orderBy,
+    where: sqlCursor.where(),
+    limit: 3,
+  });
+
+  assert.equal(sqlV1Page1.length, 3);
+  assert.equal(sqlV1Page1[0]?.firstName, "beta");
+
+  const sqlV1Page2 = await db._query.items.findMany({
+    orderBy: sqlCursor.orderBy,
+    where: sqlCursor.where(sqlCursor.serialize(sqlQbPage1.at(-1))),
+    limit: 3,
+  });
+
+  assert.equal(sqlV1Page2.length, 3);
+  assert.equal(sqlV1Page2[0]?.firstName, "epsilon");
+
+  // relations.orderBy is a function when SQL cursors are present
+  assert.equal(typeof sqlCursor.relations.orderBy, "function");
 }
 
 main().catch((err) => {

--- a/test/generateCursor.test.ts
+++ b/test/generateCursor.test.ts
@@ -1,5 +1,5 @@
 import { type Cursor, generateCursor } from "../src";
-import { and, asc, desc, eq, gt, lt, or } from "drizzle-orm";
+import { and, asc, desc, eq, gt, lt, or, sql } from "drizzle-orm";
 import { describe, expect, test } from "vitest";
 import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
 
@@ -1658,4 +1658,344 @@ describe("generateCursor", () => {
     });
   });
 
+});
+
+// ---------------------------------------------------------------------------
+// SQL expression cursors
+// ---------------------------------------------------------------------------
+
+describe("generateCursor with SQL expression cursors", () => {
+  const fullNameSql = sql`${table.firstName} || ' ' || ${table.lastName}`;
+  const upperLastNameSql = sql`upper(${table.lastName})`;
+  const lengthSql = sql`length(${table.firstName})`;
+
+  const previousData = {
+    id: 1,
+    firstName: "John",
+    middleName: "Doe",
+    lastName: "Smith",
+    phone: "123456789",
+    email: "johndoe",
+    fullName: "John Smith",
+    upperLastName: "SMITH",
+    firstNameLength: 4,
+  };
+
+  describe("SQL-only primaryCursor", () => {
+    test("default order: orderBy asc, where undefined with no data", () => {
+      const cursor = generateCursor({
+        primaryCursor: { key: "id", sql: sql`${table.id}` },
+      });
+      expect(cursor.orderBy).toEqual([asc(sql`${table.id}`)]);
+      expect(cursor.where()).toBeUndefined();
+    });
+
+    test("ASC: where uses gt", () => {
+      const cursor = generateCursor({
+        primaryCursor: { key: "id", sql: sql`${table.id}`, order: "ASC" },
+      });
+      expect(cursor.orderBy).toEqual([asc(sql`${table.id}`)]);
+      expect(cursor.where(previousData)).toEqual(
+        or(and(gt(sql`${table.id}`, previousData.id)))
+      );
+    });
+
+    test("DESC: where uses lt", () => {
+      const cursor = generateCursor({
+        primaryCursor: { key: "id", sql: sql`${table.id}`, order: "DESC" },
+      });
+      expect(cursor.orderBy).toEqual([desc(sql`${table.id}`)]);
+      expect(cursor.where(previousData)).toEqual(
+        or(and(lt(sql`${table.id}`, previousData.id)))
+      );
+    });
+  });
+
+  describe("SQL expression as secondary cursor", () => {
+    test("fullName ASC + schema primaryCursor", () => {
+      const cursor = generateCursor({
+        primaryCursor: { key: "id", schema: table.id },
+        cursors: [{ key: "fullName", sql: fullNameSql, order: "ASC" }],
+      });
+      expect(cursor.orderBy).toEqual([asc(fullNameSql), asc(table.id)]);
+      expect(cursor.where()).toBeUndefined();
+      expect(cursor.where(previousData)).toEqual(
+        or(
+          and(gt(fullNameSql, previousData.fullName)),
+          and(eq(fullNameSql, previousData.fullName), gt(table.id, previousData.id))
+        )
+      );
+    });
+
+    test("fullName DESC + schema primaryCursor", () => {
+      const cursor = generateCursor({
+        primaryCursor: { key: "id", schema: table.id },
+        cursors: [{ key: "fullName", sql: fullNameSql, order: "DESC" }],
+      });
+      expect(cursor.orderBy).toEqual([desc(fullNameSql), asc(table.id)]);
+      expect(cursor.where(previousData)).toEqual(
+        or(
+          and(lt(fullNameSql, previousData.fullName)),
+          and(eq(fullNameSql, previousData.fullName), gt(table.id, previousData.id))
+        )
+      );
+    });
+
+    test("upperLastName DESC + schema primaryCursor", () => {
+      const cursor = generateCursor({
+        primaryCursor: { key: "id", schema: table.id },
+        cursors: [{ key: "upperLastName", sql: upperLastNameSql, order: "DESC" }],
+      });
+      expect(cursor.orderBy).toEqual([desc(upperLastNameSql), asc(table.id)]);
+      expect(cursor.where(previousData)).toEqual(
+        or(
+          and(lt(upperLastNameSql, previousData.upperLastName)),
+          and(eq(upperLastNameSql, previousData.upperLastName), gt(table.id, previousData.id))
+        )
+      );
+    });
+  });
+
+  describe("mixed SQL and schema cursors", () => {
+    test("SQL length cursor first, then schema cursor, then schema primaryCursor", () => {
+      const cursor = generateCursor({
+        primaryCursor: { key: "id", schema: table.id },
+        cursors: [
+          { key: "firstNameLength", sql: lengthSql, order: "ASC" },
+          { key: "lastName", schema: table.lastName, order: "ASC" },
+        ],
+      });
+      expect(cursor.orderBy).toEqual([asc(lengthSql), asc(table.lastName), asc(table.id)]);
+      expect(cursor.where(previousData)).toEqual(
+        or(
+          and(gt(lengthSql, previousData.firstNameLength)),
+          and(eq(lengthSql, previousData.firstNameLength), gt(table.lastName, previousData.lastName)),
+          and(
+            eq(lengthSql, previousData.firstNameLength),
+            eq(table.lastName, previousData.lastName),
+            gt(table.id, previousData.id)
+          )
+        )
+      );
+    });
+
+    test("schema cursor first, then SQL length cursor, then schema primaryCursor", () => {
+      const cursor = generateCursor({
+        primaryCursor: { key: "id", schema: table.id },
+        cursors: [
+          { key: "lastName", schema: table.lastName, order: "ASC" },
+          { key: "firstNameLength", sql: lengthSql, order: "ASC" },
+        ],
+      });
+      expect(cursor.orderBy).toEqual([asc(table.lastName), asc(lengthSql), asc(table.id)]);
+      expect(cursor.where(previousData)).toEqual(
+        or(
+          and(gt(table.lastName, previousData.lastName)),
+          and(eq(table.lastName, previousData.lastName), gt(lengthSql, previousData.firstNameLength)),
+          and(
+            eq(table.lastName, previousData.lastName),
+            eq(lengthSql, previousData.firstNameLength),
+            gt(table.id, previousData.id)
+          )
+        )
+      );
+    });
+  });
+
+  describe("multiple SQL cursors with SQL primaryCursor", () => {
+    test("complex multi-SQL cursor chain", () => {
+      const cursor = generateCursor({
+        primaryCursor: { key: "id", sql: sql`${table.id}`, order: "DESC" },
+        cursors: [
+          { key: "fullName", sql: fullNameSql, order: "ASC" },
+          { key: "upperLastName", sql: upperLastNameSql, order: "DESC" },
+          { key: "firstNameLength", sql: lengthSql, order: "ASC" },
+        ],
+      });
+
+      expect(cursor.orderBy).toEqual([
+        asc(fullNameSql),
+        desc(upperLastNameSql),
+        asc(lengthSql),
+        desc(sql`${table.id}`),
+      ]);
+
+      expect(cursor.where(previousData)).toEqual(
+        or(
+          and(gt(fullNameSql, previousData.fullName)),
+          and(eq(fullNameSql, previousData.fullName), lt(upperLastNameSql, previousData.upperLastName)),
+          and(
+            eq(fullNameSql, previousData.fullName),
+            eq(upperLastNameSql, previousData.upperLastName),
+            gt(lengthSql, previousData.firstNameLength)
+          ),
+          and(
+            eq(fullNameSql, previousData.fullName),
+            eq(upperLastNameSql, previousData.upperLastName),
+            eq(lengthSql, previousData.firstNameLength),
+            lt(sql`${table.id}`, previousData.id)
+          )
+        )
+      );
+    });
+  });
+
+  describe("token round-trip with SQL cursors", () => {
+    test("serialize and parse work via key-based extraction", () => {
+      const cursor = generateCursor({
+        primaryCursor: { key: "id", schema: table.id },
+        cursors: [{ key: "fullName", sql: fullNameSql, order: "ASC" }],
+      });
+
+      const row = { id: 42, fullName: "Jane Doe" };
+      const token = cursor.serialize(row);
+      expect(token).toBeTypeOf("string");
+
+      const parsed = cursor.parse(token);
+      expect(parsed).toEqual({ id: 42, fullName: "Jane Doe" });
+    });
+
+    test("where() accepts token for SQL cursor", () => {
+      const cursor = generateCursor({
+        primaryCursor: { key: "id", schema: table.id },
+        cursors: [{ key: "fullName", sql: fullNameSql, order: "ASC" }],
+      });
+
+      const row = { id: 5, fullName: "Alice Smith" };
+      const token = cursor.serialize(row);
+
+      const fromObject = cursor.where(row);
+      const fromToken = cursor.where(token);
+      expect(fromToken).toEqual(fromObject);
+    });
+  });
+
+  describe("relations.where() with SQL cursors uses RAW", () => {
+    test("no previous data returns undefined", () => {
+      const cursor = generateCursor({
+        primaryCursor: { key: "id", schema: table.id },
+        cursors: [{ key: "fullName", sql: fullNameSql }],
+      });
+      expect(cursor.relations.where()).toBeUndefined();
+      expect(cursor.relations.where(null)).toBeUndefined();
+    });
+
+    test("SQL-only primaryCursor: single RAW entry per OR clause", () => {
+      const cursor = generateCursor({
+        primaryCursor: { key: "id", sql: sql`${table.id}`, order: "ASC" },
+      });
+      const result = cursor.relations.where({ id: 5 });
+      expect(result?.OR).toHaveLength(1);
+      expect(result?.OR.map((c) => c.RAW?.(undefined))).toEqual([
+        gt(sql`${table.id}`, 5),
+      ]);
+    });
+
+    test("SQL secondary cursor + schema primaryCursor: mixed RAW and field conditions", () => {
+      const cursor = generateCursor({
+        primaryCursor: { key: "id", schema: table.id },
+        cursors: [{ key: "fullName", sql: fullNameSql, order: "ASC" }],
+      });
+      const result = cursor.relations.where({ id: 1, fullName: "John Smith" });
+      expect(result?.OR).toHaveLength(2);
+      expect(result?.OR.map((c) => c.RAW?.(undefined))).toEqual([
+        gt(fullNameSql, "John Smith"),
+        eq(fullNameSql, "John Smith"),
+      ]);
+      expect(result?.OR.map(({ RAW: _, ...rest }) => rest)).toEqual([
+        {},
+        { id: { gt: 1 } },
+      ]);
+    });
+
+    test("SQL secondary cursor DESC: RAW uses lt for inequality", () => {
+      const cursor = generateCursor({
+        primaryCursor: { key: "id", schema: table.id },
+        cursors: [{ key: "upperLastName", sql: upperLastNameSql, order: "DESC" }],
+      });
+      const result = cursor.relations.where({ id: 1, upperLastName: "SMITH" });
+      expect(result?.OR).toHaveLength(2);
+      expect(result?.OR.map((c) => c.RAW?.(undefined))).toEqual([
+        lt(upperLastNameSql, "SMITH"),
+        eq(upperLastNameSql, "SMITH"),
+      ]);
+      expect(result?.OR.map(({ RAW: _, ...rest }) => rest)).toEqual([
+        {},
+        { id: { gt: 1 } },
+      ]);
+    });
+
+    test("multiple SQL cursors in one AND clause are combined via and()", () => {
+      const cursor = generateCursor({
+        primaryCursor: { key: "id", sql: sql`${table.id}`, order: "ASC" },
+        cursors: [
+          { key: "fullName", sql: fullNameSql, order: "ASC" },
+          { key: "upperLastName", sql: upperLastNameSql, order: "DESC" },
+        ],
+      });
+      const result = cursor.relations.where({
+        id: 1,
+        fullName: "John Smith",
+        upperLastName: "SMITH",
+      });
+      expect(result?.OR).toHaveLength(3);
+      expect(result?.OR.map((c) => c.RAW?.(undefined))).toEqual([
+        gt(fullNameSql, "John Smith"),
+        and(eq(fullNameSql, "John Smith"), lt(upperLastNameSql, "SMITH")),
+        and(eq(fullNameSql, "John Smith"), eq(upperLastNameSql, "SMITH"), gt(sql`${table.id}`, 1)),
+      ]);
+    });
+
+    test("mixed SQL and schema cursors: RAW for sql, plain fields for schema", () => {
+      const cursor = generateCursor({
+        primaryCursor: { key: "id", schema: table.id },
+        cursors: [
+          { key: "lastName", schema: table.lastName, order: "ASC" },
+          { key: "firstNameLength", sql: lengthSql, order: "ASC" },
+        ],
+      });
+      const result = cursor.relations.where({
+        id: 1,
+        lastName: "Smith",
+        firstNameLength: 4,
+      });
+      expect(result?.OR).toHaveLength(3);
+      expect(result?.OR.map((c) => c.RAW?.(undefined))).toEqual([
+        undefined,           // clause 0: schema only, no RAW
+        gt(lengthSql, 4),    // clause 1: SQL length gt
+        eq(lengthSql, 4),    // clause 2: SQL length eq
+      ]);
+      expect(result?.OR.map(({ RAW: _, ...rest }) => rest)).toEqual([
+        { lastName: { gt: "Smith" } },
+        { lastName: { eq: "Smith" } },
+        { lastName: { eq: "Smith" }, id: { gt: 1 } },
+      ]);
+    });
+
+    test("token round-trip works for relations.where with SQL cursor", () => {
+      const cursor = generateCursor({
+        primaryCursor: { key: "id", schema: table.id },
+        cursors: [{ key: "fullName", sql: fullNameSql, order: "ASC" }],
+      });
+      const token = cursor.serialize({ id: 7, fullName: "Bob Jones" });
+      const fromObject = cursor.relations.where({ id: 7, fullName: "Bob Jones" });
+      const fromToken = cursor.relations.where(token);
+      // Functions can't be deep-equal; compare RAW outputs and schema fields separately
+      expect(fromToken?.OR.map((c) => c.RAW?.(undefined))).toEqual(
+        fromObject?.OR.map((c) => c.RAW?.(undefined)),
+      );
+      expect(fromToken?.OR.map(({ RAW: _, ...rest }) => rest)).toEqual(
+        fromObject?.OR.map(({ RAW: _, ...rest }) => rest),
+      );
+    });
+
+    test("relations.orderBy is a SQL callback for SQL cursors", () => {
+      const cursor = generateCursor({
+        primaryCursor: { key: "id", schema: table.id },
+        cursors: [{ key: "fullName", sql: fullNameSql, order: "ASC" }],
+      });
+      expect(cursor.relations.orderBy).toBeInstanceOf(Function);
+      expect(cursor.relations.orderBy()).toEqual([asc(fullNameSql), asc(table.id)]);
+    });
+  });
 });

--- a/test/relations-helper.test.ts
+++ b/test/relations-helper.test.ts
@@ -1,5 +1,5 @@
 import { generateCursor } from "../src";
-import { eq, gt, lt } from "drizzle-orm";
+import { asc, eq, gt, lt, sql } from "drizzle-orm";
 import { describe, expect, test } from "vitest";
 import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
 
@@ -50,6 +50,32 @@ describe("relations helper contract", () => {
       ],
     });
     expect(fromToken).toEqual(fromObject);
+  });
+
+  test("SQL expression cursor uses RAW in relations.where and returns SQL callback for orderBy", () => {
+    const upperNameSql = sql`upper(${users.name})`;
+    const cursor = generateCursor({
+      primaryCursor: { key: "id", schema: users.id, order: "ASC" },
+      cursors: [{ key: "upperName", sql: upperNameSql, order: "ASC" }],
+    });
+
+    // orderBy is now a callback returning SQL[] — usable as RQB v2 orderBy callback
+    expect(cursor.relations.orderBy).toBeInstanceOf(Function);
+    expect(cursor.relations.orderBy()).toEqual([asc(upperNameSql), asc(users.id)]);
+
+    expect(cursor.relations.where()).toBeUndefined();
+    expect(cursor.relations.where(null)).toBeUndefined();
+
+    const result = cursor.relations.where({ id: 1, upperName: "ALICE" });
+    expect(result?.OR).toHaveLength(2);
+    expect(result?.OR.map((c) => c.RAW?.(undefined))).toEqual([
+      gt(upperNameSql, "ALICE"),
+      eq(upperNameSql, "ALICE"),
+    ]);
+    expect(result?.OR.map(({ RAW: _, ...rest }) => rest)).toEqual([
+      {},
+      { id: { gt: 1 } },
+    ]);
   });
 
   test("applies desc order in relations helper", () => {


### PR DESCRIPTION
## Summary

- Add `SQLCursor` type alongside `TableCursor` — `Cursor` is now a discriminated union of both, both exported as named types
- Make `CursorConfig<C>` generic so cursor types are fully inferred at call sites without manual annotations
- `cursor.orderBy` and `cursor.where()` branch on `"sql" in cursor` at runtime, supporting both table columns and SQL expressions
- `cursor.relations.orderBy` returns `() => SQL[]` when any cursor uses `sql` (auto-inferred via `ConfigHasSqlCursor<C>` conditional type), `Record<string, "asc"|"desc">` otherwise — no manual type annotation needed
- `cursor.relations.where()` builds `{ RAW: () => SQL }` entries for SQL cursors alongside plain field conditions for table cursors
- Compat fixtures (`drizzle-v0`, `drizzle-v1`) extended with SQL expression cursor pagination tests using `rank::text || '-' || upper(firstName)`
- README documents SQL cursor usage, RQB v2 behaviour, and the table-alias limitation for `relations.where()` with SQL expressions

## Test plan

- [x] `pnpm exec vitest run` — 193 tests pass
- [x] `pnpm exec tsc --noEmit` — no type errors
- [x] `pnpm run test:compat` — both drizzle-v0 and drizzle-v1 fixtures pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for SQL-expression-based cursors. Users can now define cursor entries using Drizzle SQL expressions for enhanced pagination flexibility alongside traditional table-column cursors.

* **Documentation**
  * Updated README with SQL cursor documentation, including usage examples, type references, and best practices for query builders and pagination.

* **Chores**
  * Bumped version to 0.7.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->